### PR TITLE
Added support for more than 1000 address spaces in storage table

### DIFF
--- a/src/module/IPAM/Public/Get-AddressSpace.ps1
+++ b/src/module/IPAM/Public/Get-AddressSpace.ps1
@@ -50,8 +50,18 @@ Function Get-AddressSpace {
         }
 
         # Return all Address Spaces from Storage Table
-        (Invoke-RestMethod @params).value
+        $ipamResult = (Invoke-RestMethod @params -ResponseHeadersVariable responseHeaders).value
 
+        while ($responseHeaders.ContainsKey("x-ms-continuation-NextRowKey")) { 
+            $nextPartitionKey = $responseHeaders["x-ms-continuation-NextPartitionKey"][0]
+            $nextRowKey = $responseHeaders["x-ms-continuation-NextRowKey"][0]
+            $params."Uri" = ('https://{0}.table.core.windows.net/{1}?NextPartitionKey={2}&NextRowKey={3}' -f $StorageAccountName, $StorageTableName, $nextPartitionKey, $nextRowKey)
+            $ipamResponse = (Invoke-RestMethod @params -ResponseHeadersVariable responseHeaders).value
+         
+            $ipamResult += $ipamResponse
+        }
+        
+        return $ipamResult
     }
     catch {
 

--- a/src/module/IPAM/Public/Get-AddressSpace.ps1
+++ b/src/module/IPAM/Public/Get-AddressSpace.ps1
@@ -50,18 +50,18 @@ Function Get-AddressSpace {
         }
 
         # Return all Address Spaces from Storage Table
-        $ipamResult = (Invoke-RestMethod @params -ResponseHeadersVariable responseHeaders).value
+        $addressSpaces = (Invoke-RestMethod @params -ResponseHeadersVariable responseHeaders).value
 
         while ($responseHeaders.ContainsKey("x-ms-continuation-NextRowKey")) { 
             $nextPartitionKey = $responseHeaders["x-ms-continuation-NextPartitionKey"][0]
             $nextRowKey = $responseHeaders["x-ms-continuation-NextRowKey"][0]
             $params."Uri" = ('https://{0}.table.core.windows.net/{1}?NextPartitionKey={2}&NextRowKey={3}' -f $StorageAccountName, $StorageTableName, $nextPartitionKey, $nextRowKey)
-            $ipamResponse = (Invoke-RestMethod @params -ResponseHeadersVariable responseHeaders).value
+            $additionalAddressSpaces = (Invoke-RestMethod @params -ResponseHeadersVariable responseHeaders).value
          
-            $ipamResult += $ipamResponse
+            $addressSpaces += $additionalAddressSpaces
         }
         
-        return $ipamResult
+        return $addressSpaces
     }
     catch {
 


### PR DESCRIPTION
The current implementation of Get-AddessSpace does not implement pagination/continuation tokens. The storage table API has a limit of 1000 results per API call. This means that when there are more present in the table, not all address spaces will be returned. 

PR contains an implementation that uses the response header continuation tokens to retrieve all address spaces from the storage table api.